### PR TITLE
Ensure up-to-date snapshot is taken with the latest dictionary

### DIFF
--- a/ivory-cli/src/main/scala/com/ambiata/ivory/cli/snapshot.scala
+++ b/ivory-cli/src/main/scala/com/ambiata/ivory/cli/snapshot.scala
@@ -51,13 +51,12 @@ object snapshot extends IvoryApp {
       for {
         of   <- Extract.parse(configuration, c.formats)
         res  <- IvoryRetire.takeSnapshot(repo, Date.fromLocalDate(c.date))
-        meta = res.meta
-        _    <- ResultT.when(of.outputs.nonEmpty, SquashJob.squashFromSnapshotWith(repo, meta, c.squash) { (input, dictionary) =>
+        _    <- ResultT.when(of.outputs.nonEmpty, SquashJob.squashFromSnapshotWith(repo, res, c.squash) { (input, dictionary) =>
           Extraction.extract(of, repo.toIvoryLocation(input), dictionary).run(IvoryRead.prod(repo)).map(_ -> of.outputs.map(_._2))
         })
       } yield List(
         banner,
-        s"Output path: ${meta.snapshotId}",
+        s"Output path: ${res.manifest.snapshotId}",
         res.incremental.cata((incr: SnapshotManifest) => s"Incremental snapshot used: ${incr.snapshotId}", "No Incremental Snapshot was used."),
         "Status -- SUCCESS")
   })

--- a/ivory-core/src/main/scala/com/ambiata/ivory/core/OptionTPlus.scala
+++ b/ivory-core/src/main/scala/com/ambiata/ivory/core/OptionTPlus.scala
@@ -1,0 +1,12 @@
+package com.ambiata.ivory.core
+
+import scalaz._, Scalaz._
+
+object OptionTPlus {
+
+  def fromOption[M[_]: Applicative, A](a: Option[A]): OptionT[M, A] =
+    OptionT(a.pure[M])
+
+  def when[M[_]: Applicative, A](b: Boolean, a: => A): OptionT[M, A] =
+    if (b) OptionT.some(a) else OptionT.none
+}

--- a/ivory-core/src/test/scala/com/ambiata/ivory/core/OptionTPlusSpec.scala
+++ b/ivory-core/src/test/scala/com/ambiata/ivory/core/OptionTPlusSpec.scala
@@ -1,0 +1,23 @@
+package com.ambiata.ivory.core
+
+import org.specs2._
+import scalaz._, Scalaz._
+
+class OptionTPlusSpec extends Specification with ScalaCheck { def is = s2"""
+  Create OptionT from an Option                 $fromOption
+  When true create a Some value                 $whenTrue
+  When false ignore input and return None       $whenFalse
+
+"""
+
+  def fromOption = prop((o: Option[String]) =>
+    OptionTPlus.fromOption[Id, String](o).run ==== o
+  )
+
+  def whenTrue = prop((s: String) =>
+    OptionTPlus.when[Id, String](true, s).run must beSome(s)
+  )
+
+  def whenFalse =
+    OptionTPlus.when[Id, String](false, sys.error("")).run must beNone
+}

--- a/ivory-operation/src/main/scala/com/ambiata/ivory/operation/extraction/Chord.scala
+++ b/ivory-operation/src/main/scala/com/ambiata/ivory/operation/extraction/Chord.scala
@@ -35,7 +35,7 @@ object Chord {
     _                    = println(s"Earliest date in chord file is '${entities.earliestDate}'")
     _                    = println(s"Latest date in chord file is '${entities.latestDate}'")
     store               <- Metadata.latestFeatureStoreOrFail(repository)
-    snapshot            <- if (takeSnapshot) Snapshots.takeSnapshot(repository, entities.earliestDate).map(_.meta.pure[Option])
+    snapshot            <- if (takeSnapshot) Snapshots.takeSnapshot(repository, entities.earliestDate).map(_.manifest.pure[Option])
                            else              SnapshotManifest.latestSnapshot(repository, entities.earliestDate).run
     out                 <- runChord(repository, store, entities, snapshot, windowing)
   } yield out

--- a/ivory-operation/src/main/scala/com/ambiata/ivory/operation/extraction/Snapshots.scala
+++ b/ivory-operation/src/main/scala/com/ambiata/ivory/operation/extraction/Snapshots.scala
@@ -121,15 +121,6 @@ object Snapshots {
       _               <- Hdfs.safe(SnapshotJob.run(repository, conf, dictionary, reducers.toInt, snapshotDate, factsetsGlobs, outputPath, windows, incrementalPath, codec))
     } yield ()
 
-  def dictionaryForSnapshot(repository: Repository, meta: SnapshotManifest): ResultTIO[Dictionary] =
-    meta.storeOrCommitId.b.cata(
-      commitId => for {
-        commit <- commitFromIvory(repository, commitId)
-        dict   <- dictionaryFromIvory(repository, commit.dictionaryId)
-      } yield dict,
-      latestDictionaryFromIvory(repository)
-    )
-
   def newFactsetGlobs(repo: Repository, partitions: List[SnapshotPartition]): ResultTIO[List[Prioritized[FactsetGlob]]] =
     partitions.traverseU(s => FeatureStoreGlob.between(repo, s.store, s.start, s.end).map(_.globs)).map(_.flatten)
 }

--- a/ivory-operation/src/main/scala/com/ambiata/ivory/operation/extraction/squash/SquashJob.scala
+++ b/ivory-operation/src/main/scala/com/ambiata/ivory/operation/extraction/squash/SquashJob.scala
@@ -4,7 +4,7 @@ import com.ambiata.ivory.core._
 import com.ambiata.ivory.lookup.{FeatureIdLookup, FeatureReduction, FeatureReductionLookup}
 import com.ambiata.ivory.operation.extraction.SnapshotJob
 import com.ambiata.ivory.storage.lookup.{ReducerLookups, ReducerSize}
-import com.ambiata.ivory.storage.metadata.{Metadata, SnapshotManifest}
+import com.ambiata.ivory.storage.metadata.{Metadata, SnapshotLatestSummary}
 import com.ambiata.mundane.control._
 import com.ambiata.mundane.io.FileName
 import com.ambiata.mundane.io.MemoryConversions._
@@ -22,10 +22,10 @@ import scalaz._, Scalaz._, effect.IO
 
 object SquashJob {
 
-  def squashFromSnapshotWith[A](repository: Repository, snapmeta: SnapshotManifest, conf: SquashConfig)
+  def squashFromSnapshotWith[A](repository: Repository, snapmeta: SnapshotLatestSummary, conf: SquashConfig)
                                (f: (Key, Dictionary) => ResultTIO[(A, List[IvoryLocation])]): ResultTIO[A] = for {
-    dictionary      <- Metadata.latestDictionaryFromIvory(repository)
-    toSquash        <- squash(repository, dictionary, Repository.snapshot(snapmeta.snapshotId), snapmeta.date, conf)
+    dictionary      <- Metadata.dictionaryFromIvory(repository, snapmeta.dictionaryId)
+    toSquash        <- squash(repository, dictionary, Repository.snapshot(snapmeta.manifest.snapshotId), snapmeta.manifest.date, conf)
     (profile, key, doSquash) =  toSquash
     a               <- f(key, dictionary)
     _               <- ResultT.when(doSquash, for {

--- a/ivory-operation/src/main/scala/com/ambiata/ivory/operation/extraction/squash/SquashJob.scala
+++ b/ivory-operation/src/main/scala/com/ambiata/ivory/operation/extraction/squash/SquashJob.scala
@@ -24,8 +24,7 @@ object SquashJob {
 
   def squashFromSnapshotWith[A](repository: Repository, snapmeta: SnapshotManifest, conf: SquashConfig)
                                (f: (Key, Dictionary) => ResultTIO[(A, List[IvoryLocation])]): ResultTIO[A] = for {
-    dictionaryId    <- SnapshotManifest.dictionaryIdForSnapshot(repository, snapmeta)
-    dictionary      <- Metadata.dictionaryFromIvory(repository, dictionaryId)
+    dictionary      <- Metadata.latestDictionaryFromIvory(repository)
     toSquash        <- squash(repository, dictionary, Repository.snapshot(snapmeta.snapshotId), snapmeta.date, conf)
     (profile, key, doSquash) =  toSquash
     a               <- f(key, dictionary)

--- a/ivory-operation/src/main/scala/com/ambiata/ivory/operation/extraction/squash/SquashJob.scala
+++ b/ivory-operation/src/main/scala/com/ambiata/ivory/operation/extraction/squash/SquashJob.scala
@@ -2,9 +2,9 @@ package com.ambiata.ivory.operation.extraction.squash
 
 import com.ambiata.ivory.core._
 import com.ambiata.ivory.lookup.{FeatureIdLookup, FeatureReduction, FeatureReductionLookup}
-import com.ambiata.ivory.operation.extraction.{Snapshots, SnapshotJob}
+import com.ambiata.ivory.operation.extraction.SnapshotJob
 import com.ambiata.ivory.storage.lookup.{ReducerLookups, ReducerSize}
-import com.ambiata.ivory.storage.metadata.SnapshotManifest
+import com.ambiata.ivory.storage.metadata.{Metadata, SnapshotManifest}
 import com.ambiata.mundane.control._
 import com.ambiata.mundane.io.FileName
 import com.ambiata.mundane.io.MemoryConversions._
@@ -24,7 +24,8 @@ object SquashJob {
 
   def squashFromSnapshotWith[A](repository: Repository, snapmeta: SnapshotManifest, conf: SquashConfig)
                                (f: (Key, Dictionary) => ResultTIO[(A, List[IvoryLocation])]): ResultTIO[A] = for {
-    dictionary      <- Snapshots.dictionaryForSnapshot(repository, snapmeta)
+    dictionaryId    <- SnapshotManifest.dictionaryIdForSnapshot(repository, snapmeta)
+    dictionary      <- Metadata.dictionaryFromIvory(repository, dictionaryId)
     toSquash        <- squash(repository, dictionary, Repository.snapshot(snapmeta.snapshotId), snapmeta.date, conf)
     (profile, key, doSquash) =  toSquash
     a               <- f(key, dictionary)

--- a/ivory-operation/src/test/scala/com/ambiata/ivory/operation/display/PrintFactsSpec.scala
+++ b/ivory-operation/src/test/scala/com/ambiata/ivory/operation/display/PrintFactsSpec.scala
@@ -24,7 +24,7 @@ class PrintFactsSpec extends Specification with SampleFacts { def is = s2"""
       buffer     = new StringBuffer
       stringBufferLogging = (s: String) => IO { buffer.append(s+"\n"); ()}
       _         <- ResultT.fromIO(PrintFacts.print(
-        List(repo.toIvoryLocation(Repository.snapshot(snapshot1.meta.snapshotId)).toHdfsPath),
+        List(repo.toIvoryLocation(Repository.snapshot(snapshot1.manifest.snapshotId)).toHdfsPath),
         repo.configuration,
         delim = "|",
         tombstone = "NA",

--- a/ivory-operation/src/test/scala/com/ambiata/ivory/operation/extraction/SnapshotsSpec.scala
+++ b/ivory-operation/src/test/scala/com/ambiata/ivory/operation/extraction/SnapshotsSpec.scala
@@ -49,7 +49,7 @@ class SnapshotsSpec extends Specification with SampleFacts with ScalaCheck { def
     RepositoryBuilder.using { repo => for {
         _ <- RepositoryBuilder.createRepo(repo, vdict.vd.dictionary, List(deprioritized, facts ++ oldfacts))
         s <- Snapshots.takeSnapshot(repo, fact.date)
-        f  = valueFromSequenceFile[Fact](repo.toIvoryLocation(Repository.snapshot(s.meta.snapshotId)).toHdfs).run(repo.scoobiConfiguration)
+        f  = valueFromSequenceFile[Fact](repo.toIvoryLocation(Repository.snapshot(s.manifest.snapshotId)).toHdfs).run(repo.scoobiConfiguration)
       } yield f
     }.map(_.toSet) must beOkValue((oldfacts.sortBy(_.date).lastOption.toList ++ facts).toSet)
   }).set(minTestsOk = 3)
@@ -66,8 +66,8 @@ class SnapshotsSpec extends Specification with SampleFacts with ScalaCheck { def
           _ <- RepositoryBuilder.createFactset(repo, facts2)
           res2 <- Snapshots.takeSnapshot(repo, fact.date)
         } yield (res, res2.incremental.map(_.snapshotId))) must beOkLike(
-          (t: (SnapshotJobSummary[SnapshotManifest], Option[SnapshotId])) =>
-            t._2.cata((sid: SnapshotId) => sid must_== t._1.meta.snapshotId, SpecsFailure("No incremental was used in the second snapshot")))
+          (t: (SnapshotLatestSummary, Option[SnapshotId])) =>
+            t._2.cata((sid: SnapshotId) => sid must_== t._1.manifest.snapshotId, SpecsFailure("No incremental was used in the second snapshot")))
     }).set(minTestsOk = 3)
 
   def sets = propNoShrink((concrete: FeatureId, virtual: FeatureId, window: Window, date: Date, time: Time, entity: Int) => {
@@ -94,7 +94,7 @@ class SnapshotsSpec extends Specification with SampleFacts with ScalaCheck { def
     RepositoryBuilder.using { repo => for {
         _ <- RepositoryBuilder.createRepo(repo, dictionary, List(facts ++ outer))
         s <- Snapshots.takeSnapshot(repo, date)
-        f  = valueFromSequenceFile[Fact](repo.toIvoryLocation(Repository.snapshot(s.meta.snapshotId)).toHdfs).run(repo.scoobiConfiguration)
+        f  = valueFromSequenceFile[Fact](repo.toIvoryLocation(Repository.snapshot(s.manifest.snapshotId)).toHdfs).run(repo.scoobiConfiguration)
       } yield f
     }.map(_.toSet) must beOkValue((outer.sortBy(f => f.datetime.long).filter(_.date.isBeforeOrEqual(date)).lastOption.toList ++ facts).toSet)
   }).set(minTestsOk = 3)

--- a/ivory-operation/src/test/scala/com/ambiata/ivory/operation/extraction/output/DenseOutputSpec.scala
+++ b/ivory-operation/src/test/scala/com/ambiata/ivory/operation/extraction/output/DenseOutputSpec.scala
@@ -68,7 +68,7 @@ class DenseOutputSpec extends Specification with SampleFacts with ThrownExpectat
         dense <- IvoryLocation.fromUri((dir </> "dense").path, IvoryConfiguration.Empty)
         res   <- Snapshots.takeSnapshot(repo, Date.maxValue)
 
-        meta      = res.meta
+        meta      = res.manifest
         input     = repo.toIvoryLocation(Repository.snapshot(meta.snapshotId))
         _                <- DenseOutput.createWithDictionary(repo, input, dense, dictionary, '|', "NA")
         dictLocation     <- IvoryLocation.fromUri((dir </> "dense" </> ".dictionary").path, IvoryConfiguration.Empty)

--- a/ivory-operation/src/test/scala/com/ambiata/ivory/operation/extraction/output/SparseOutputSpec.scala
+++ b/ivory-operation/src/test/scala/com/ambiata/ivory/operation/extraction/output/SparseOutputSpec.scala
@@ -49,7 +49,7 @@ class SparseOutputSpec extends Specification with SampleFacts with ThrownExpecta
         _               <- RepositoryBuilder.createRepo(repo, dictionary, facts)
         eav             <- IvoryLocation.fromUri((dir </> "eav").path, IvoryConfiguration.Empty)
         res             <- Snapshots.takeSnapshot(repo, Date.maxValue)
-        meta            = res.meta
+        meta            = res.manifest
         input           = repo.toIvoryLocation(Repository.snapshot(meta.snapshotId))
         _               <- SparseOutput.extractWithDictionary(repo, input, eav, dictionary, '|', "NA")
         dictLocation    <- IvoryLocation.fromUri((dir </> "eav" </> ".dictionary").path, IvoryConfiguration.Empty)

--- a/ivory-operation/src/test/scala/com/ambiata/ivory/operation/extraction/squash/SquashSpec.scala
+++ b/ivory-operation/src/test/scala/com/ambiata/ivory/operation/extraction/squash/SquashSpec.scala
@@ -34,9 +34,8 @@ class SquashSpec extends Specification with SampleFacts with ScalaCheck { def is
     RepositoryBuilder.using { repo => for {
       _ <- RepositoryBuilder.createRepo(repo, dict, List(allFacts))
       res <- Snapshots.takeSnapshot(repo, sf.date)
-      s     = res.meta
       out   = repo.toIvoryLocation(Key(KeyName.unsafe("out"))): IvoryLocation
-      f <- SquashJob.squashFromSnapshotWith(repo, s, SquashConfig.testing)((key, _) =>
+      f <- SquashJob.squashFromSnapshotWith(repo, res, SquashConfig.testing)((key, _) =>
         ResultT.safe(postProcess(valueFromSequenceFile[Fact](repo.toIvoryLocation(key).toHdfs)
           .run(repo.scoobiConfiguration).toList) -> List(out))
       )

--- a/ivory-storage/src/test/scala/com/ambiata/ivory/storage/metadata/SnapshotManifestSpec.scala
+++ b/ivory-storage/src/test/scala/com/ambiata/ivory/storage/metadata/SnapshotManifestSpec.scala
@@ -125,7 +125,7 @@ SnapshotManifest Properties
         store     <- Metadata.incrementFeatureStore(List(factsetId)).run(IvoryRead.testing(repo))
         _         <- Metadata.dictionaryToIvory(repo, Dictionary.empty)
         _         <- writeFactsetVersion(repo, List(factsetId))
-        snapshot  <- SnapshotManifest.latestUpToDateSnapshot(repo, dates.now).run
+        snapshot  <- SnapshotManifest.latestUpToDateSnapshot(repo, dates.now).run.map(_.map(_.manifest))
       } yield snapshot must beUpToDate(repo, dates.now)
 
     } must beOkResult
@@ -140,10 +140,10 @@ SnapshotManifest Properties
         commitId  <- Metadata.findOrCreateLatestCommitId(repo)
         _         <- NewSnapshotManifest.save(repo, NewSnapshotManifest.newSnapshotMeta(snapshotId, date, commitId))
         // Load a snapshot where the dictionary is still valid
-        snapshot1 <- SnapshotManifest.latestUpToDateSnapshot(repo, date).run
+        snapshot1 <- SnapshotManifest.latestUpToDateSnapshot(repo, date).run.map(_.map(_.manifest))
         // Create a newer dictionary
         _         <- Metadata.dictionaryToIvory(repo, Dictionary.empty)
-        snapshot2 <- SnapshotManifest.latestUpToDateSnapshot(repo, date).run
+        snapshot2 <- SnapshotManifest.latestUpToDateSnapshot(repo, date).run.map(_.map(_.manifest))
       } yield (snapshot1.map(_.snapshotId), snapshot2.map(_.snapshotId))
 
     } must beOkValue(Some(snapshotId) -> None)


### PR DESCRIPTION
This started as something else, putting the check in `SquashJob.squashFromSnapshotWith`, but slowly moved up to where it is. I _think_ making the dictionary check in `SnapshotManifest` (or at least `Snapshots`) makes more sense.


