### PR TITLE
Property express Encoding types without inheritance

### DIFF
--- a/ivory-core/src/main/scala/com/ambiata/ivory/core/Encoding.scala
+++ b/ivory-core/src/main/scala/com/ambiata/ivory/core/Encoding.scala
@@ -37,7 +37,7 @@ sealed trait SubEncoding {
 case class SubPrim(e: PrimitiveEncoding) extends SubEncoding
 case class SubStruct(e: StructEncoding) extends SubEncoding
 
-case class StructEncoding(values: Map[String, StructEncodedValue]) {
+case class StructEncoding(values: Map[String, StructEncodedValue[PrimitiveEncoding]]) {
 
   def toEncoding: Encoding =
     EncodingStruct(this)
@@ -49,17 +49,20 @@ case class ListEncoding(encoding: SubEncoding) {
 }
 
 // NOTE: For now we don't support nested structs
-case class StructEncodedValue(encoding: PrimitiveEncoding, optional: Boolean = false) {
-  def opt: StructEncodedValue =
+case class StructEncodedValue[A](encoding: A, optional: Boolean = false) {
+  def opt: StructEncodedValue[A] =
     if (optional) this else copy(optional = true)
+
+  def map[B](f: A => B): StructEncodedValue[B] =
+    StructEncodedValue(f(encoding), optional)
 }
 
 object StructEncodedValue {
 
-  def optional(encoding: PrimitiveEncoding): StructEncodedValue =
+  def optional(encoding: PrimitiveEncoding): StructEncodedValue[PrimitiveEncoding] =
     StructEncodedValue(encoding, optional = true)
 
-  def mandatory(encoding: PrimitiveEncoding): StructEncodedValue =
+  def mandatory(encoding: PrimitiveEncoding): StructEncodedValue[PrimitiveEncoding] =
     StructEncodedValue(encoding, optional = false)
 }
 

--- a/ivory-core/src/main/scala/com/ambiata/ivory/core/Encoding.scala
+++ b/ivory-core/src/main/scala/com/ambiata/ivory/core/Encoding.scala
@@ -1,8 +1,22 @@
 package com.ambiata.ivory.core
 
-sealed trait Encoding
+sealed trait Encoding {
 
-sealed trait PrimitiveEncoding extends SubEncoding
+  def fold[A](p: PrimitiveEncoding => A, s: StructEncoding => A, l: ListEncoding => A): A = this match {
+    case EncodingPrim(e) => p(e)
+    case EncodingStruct(e) => s(e)
+    case EncodingList(e) => l(e)
+  }
+}
+case class EncodingPrim(encoding: PrimitiveEncoding) extends Encoding
+case class EncodingStruct(encoding: StructEncoding) extends Encoding
+case class EncodingList(encoding: ListEncoding) extends Encoding
+
+sealed trait PrimitiveEncoding {
+
+  def toEncoding: Encoding =
+    EncodingPrim(this)
+}
 case object BooleanEncoding   extends PrimitiveEncoding
 case object IntEncoding       extends PrimitiveEncoding
 case object LongEncoding      extends PrimitiveEncoding
@@ -10,10 +24,29 @@ case object DoubleEncoding    extends PrimitiveEncoding
 case object StringEncoding    extends PrimitiveEncoding
 case object DateEncoding      extends PrimitiveEncoding
 
-sealed trait SubEncoding extends Encoding
+sealed trait SubEncoding {
 
-case class StructEncoding(values: Map[String, StructEncodedValue]) extends SubEncoding
-case class ListEncoding(encoding: SubEncoding) extends Encoding
+  def fold[A](p: PrimitiveEncoding => A, s: StructEncoding => A): A = this match {
+    case SubPrim(e) => p(e)
+    case SubStruct(e) => s(e)
+  }
+
+  def toEncoding: Encoding =
+    fold(_.toEncoding, _.toEncoding)
+}
+case class SubPrim(e: PrimitiveEncoding) extends SubEncoding
+case class SubStruct(e: StructEncoding) extends SubEncoding
+
+case class StructEncoding(values: Map[String, StructEncodedValue]) {
+
+  def toEncoding: Encoding =
+    EncodingStruct(this)
+}
+case class ListEncoding(encoding: SubEncoding) {
+
+  def toEncoding: Encoding =
+    EncodingList(this)
+}
 
 // NOTE: For now we don't support nested structs
 case class StructEncodedValue(encoding: PrimitiveEncoding, optional: Boolean = false) {
@@ -33,13 +66,13 @@ object StructEncodedValue {
 object Encoding {
 
   def render(enc: Encoding): String = enc match {
-    case ListEncoding(e) => "[" + renderSub(e) + "]"
-    case e: SubEncoding  => renderSub(e)
+    case EncodingList(ListEncoding(e)) => "[" + renderSub(e) + "]"
+    case EncodingSub(e) => renderSub(e)
   }
 
   private def renderSub(enc: SubEncoding): String = enc match {
-    case e: PrimitiveEncoding => renderPrimitive(e)
-    case StructEncoding(m)    => "(" + m.map {
+    case SubPrim(e) => renderPrimitive(e)
+    case SubStruct(m)    => "(" + m.values.map {
       case (n, v) => n + ":" + renderPrimitive(v.encoding) + (if (v.optional) "*" else "")
     }.mkString(",") + ")"
   }
@@ -54,21 +87,18 @@ object Encoding {
   }
 
   def isPrimitive(enc: Encoding): Boolean =
-    enc match {
-      case _: PrimitiveEncoding => true
-      case _: StructEncoding    => false
-      case _: ListEncoding      => false
-    }
+    enc.fold(_ => true, _ => false, _ => false)
 
   def isNumeric(enc: Encoding): Boolean =
+    enc.fold(isNumericPrim, _ => false, _ => false)
+
+  def isNumericPrim(enc: PrimitiveEncoding): Boolean =
     enc match {
+      case StringEncoding    => false
       case IntEncoding       => true
       case LongEncoding      => true
       case DoubleEncoding    => true
       case BooleanEncoding   => false
       case DateEncoding      => false
-      case StructEncoding(_) => false
-      case ListEncoding(_)   => false
-      case StringEncoding    => false
     }
 }

--- a/ivory-core/src/main/scala/com/ambiata/ivory/core/Encoding.scala
+++ b/ivory-core/src/main/scala/com/ambiata/ivory/core/Encoding.scala
@@ -1,5 +1,39 @@
 package com.ambiata.ivory.core
 
+/**
+ * Represents the type of encodings possible for a given feature.
+ *
+ * The hierarchy looks like:
+ *
+ * ```
+ *
+ *                     Encoding
+ *                        o
+ *                        |
+ *              +-------------------+
+ *              |         |         |
+ *              o         |         o
+ *      EncodingPrim(SE)  |   EncodingList(LE)
+ *                        o
+ *                 EncodingStruct(PE)
+ *
+ *                   SubEncoding
+ *                        o
+ *                        |
+ *              +------------------+
+ *              |                  |
+ *              o                  o
+ *          SubPrim(PE)       SubStruct(SE)
+ *
+ *                 PrimitiveEncoding (PE)
+ *                       /|\
+ *                {string,int,....}
+ *
+ *             ListEncoding([SubEncoding]) (LE)
+ *
+ *     StructEncoding({name : PrimitiveEncoding}) (SE)
+ * ```
+ */
 sealed trait Encoding {
 
   def fold[A](p: PrimitiveEncoding => A, s: StructEncoding => A, l: ListEncoding => A): A = this match {

--- a/ivory-core/src/main/scala/com/ambiata/ivory/core/Encoding.scala
+++ b/ivory-core/src/main/scala/com/ambiata/ivory/core/Encoding.scala
@@ -1,7 +1,5 @@
 package com.ambiata.ivory.core
 
-import scala.math.{Ordering => SOrdering}
-
 sealed trait Encoding
 
 sealed trait PrimitiveEncoding extends SubEncoding

--- a/ivory-core/src/main/scala/com/ambiata/ivory/core/Encoding.scala
+++ b/ivory-core/src/main/scala/com/ambiata/ivory/core/Encoding.scala
@@ -59,7 +59,7 @@ case class ListEncoding(encoding: SubEncoding) {
 }
 
 // NOTE: For now we don't support nested structs
-case class StructEncodedValue[A](encoding: A, optional: Boolean = false) {
+case class StructEncodedValue[A](encoding: A, optional: Boolean) {
   def opt: StructEncodedValue[A] =
     if (optional) this else copy(optional = true)
 

--- a/ivory-core/src/main/scala/com/ambiata/ivory/core/Expression.scala
+++ b/ivory-core/src/main/scala/com/ambiata/ivory/core/Expression.scala
@@ -115,7 +115,7 @@ object Expression {
       case Latest           => ok
       case LatestN(i)       => if (i > 0) ok else "Only positive values supported for latestN".left
       case (Sum | Min | Max | Mean | Gradient | StandardDeviation) =>
-        if (Encoding.isNumeric(subenc)) ok else"Non-numeric encoding not supported".left
+        if (Encoding.isNumericPrim(subenc)) ok else"Non-numeric encoding not supported".left
       case DaysSince => subenc match {
         case DateEncoding   => ok
         case _              => "Non-date encoding not supported".left
@@ -152,59 +152,63 @@ object Expression {
       }
       case Inverse(other)                =>
         if (Encoding.isNumeric(expressionEncoding(other, encoding))) ok else "Non numeric encoding for inverse".left
-      case SumBy(key, field)             => encoding match {
-        case StructEncoding(values) => for {
-           k <- values.get(key).map(_.encoding).toRightDisjunction(s"Struct field not found '$key'")
-           f <- values.get(field).map(_.encoding).toRightDisjunction(s"Struct field not found '$field'")
+      case SumBy(key, field)             => encoding.fold(
+        _ => "sum_by requires struct encoding".left,
+        s => for {
+           k <- s.values.get(key).map(_.encoding).toRightDisjunction(s"Struct field not found '$key'")
+           f <- s.values.get(field).map(_.encoding).toRightDisjunction(s"Struct field not found '$field'")
            _ <- (k, f) match {
              case (StringEncoding, fieldEncoding) =>
-               if (Encoding.isNumeric(fieldEncoding)) ok else "sum_by field is required to be numerical".left
+               if (Encoding.isNumericPrim(fieldEncoding)) ok else "sum_by field is required to be numerical".left
              case _ => "sum_by key is required to be a string".left
            }
-        } yield ()
-        case _                           => "sum_by requires struct encoding".left
-      }
-      case LatestBy(key)                 => encoding match {
-        case StructEncoding(values) => for {
-           k <- values.get(key).toRightDisjunction(s"Struct field not found '$key'")
+        } yield (),
+        _ => "sum_by requires struct encoding".left
+      )
+      case LatestBy(key)                 => encoding.fold(
+        _ => "latest_by requires struct encoding".left,
+        s => for {
+           k <- s.values.get(key).toRightDisjunction(s"Struct field not found '$key'")
            _ <- k match {
              case StructEncodedValue(StringEncoding, false) => ok
              case _ => "latest_by key is required to be a non-optional string".left
            }
-        } yield ()
-        case _                           => "latest_by requires struct encoding".left
-      }
-      case CountBySecondary(key, field)             => encoding match {
-        case StructEncoding(values) => for {
-          k <- values.get(key).map(_.encoding).toRightDisjunction(s"Struct field not found '$key'")
-          f <- values.get(field).map(_.encoding).toRightDisjunction(s"Struct field not found '$field'")
+        } yield (),
+        _ => "latest_by requires struct encoding".left
+      )
+      case CountBySecondary(key, field)             => encoding.fold(
+        _ => "count_by requires struct encoding".left,
+        s => for {
+          k <- s.values.get(key).map(_.encoding).toRightDisjunction(s"Struct field not found '$key'")
+          f <- s.values.get(field).map(_.encoding).toRightDisjunction(s"Struct field not found '$field'")
           _ <- (k, f) match {
             case (StringEncoding, StringEncoding) => ok
             case _                                => "count_by fields are required to be strings".left
           }
-        } yield ()
-        case _                           => "count_by requires struct encoding".left
-      }
-      case BasicExpression(sexp)         => encoding match {
-        case pe: PrimitiveEncoding       => validateSub(sexp, pe)
-        case se: StructEncoding          => sexp match {
+        } yield (),
+        _ => "count_by requires struct encoding".left
+      )
+      case BasicExpression(sexp)         => encoding.fold(
+        pe => validateSub(sexp, pe),
+        se => sexp match {
           // These two operations work on structs
           case Latest     => ok
           case LatestN(i) => if (i > 0) ok else "Only positive values supported for latestN".left
           case _          => "Struct encoding not supported for the given expression".left
-        }
-        case se: ListEncoding          => sexp match {
+        },
+        se => sexp match {
           // Latest works on everything
           case Latest     => ok
           case _          => "List encoding not supported for the given expression".left
         }
-      }
-      case StructExpression(field, sexp) => encoding match {
-        case StructEncoding(values) =>
-          values.get(field).toRightDisjunction(s"Struct field not found '$field'")
-            .flatMap(sev => validateSub(sexp, sev.encoding))
-        case _                      => "Expression with a field not supported".left
-      }
+      )
+      case StructExpression(field, sexp) => encoding.fold(
+        _ => "Expression with a field not supported".left,
+        s =>
+          s.values.get(field).toRightDisjunction(s"Struct field not found '$field'")
+            .flatMap(sev => validateSub(sexp, sev.encoding)),
+        _ => "Expression with a field not supported".left
+      )
     }).leftMap(_ + " " + asString(exp))
   }
 
@@ -217,52 +221,54 @@ object Expression {
   def expressionEncoding(expression: Expression, source: Encoding): Encoding = {
     def getExpressionEncoding(exp: SubExpression, enc: Encoding): Encoding = exp match {
       case Latest              => enc
-      case LatestN(_)          => enc match {
-                                    case sub: SubEncoding  => ListEncoding(sub)
-                                    // Nesting is forbidden, this is just to make the match exhaustive
-                                    case _  : ListEncoding => enc
-                                  }
+      case LatestN(_)          => enc.fold(
+        e => EncodingList(ListEncoding(SubPrim(e))),
+        e => EncodingList(ListEncoding(SubStruct(e))),
+        // Nesting is forbidden, this is just to make the match exhaustive
+        _ => enc
+      )
       case Sum                 => enc
-      case CountUnique         => LongEncoding
+      case CountUnique         => LongEncoding.toEncoding
       case Min                 => enc
       case Max                 => enc
-      case Mean                => DoubleEncoding
-      case Gradient            => DoubleEncoding
-      case StandardDeviation   => DoubleEncoding
-      case NumFlips            => LongEncoding
-      case DaysSince           => IntEncoding
-      case CountBy             => StructEncoding(Map())
-      case DaysSinceEarliestBy => StructEncoding(Map())
-      case DaysSinceLatestBy   => StructEncoding(Map())
-      case Proportion(_)       => DoubleEncoding
+      case Mean                => DoubleEncoding.toEncoding
+      case Gradient            => DoubleEncoding.toEncoding
+      case StandardDeviation   => DoubleEncoding.toEncoding
+      case NumFlips            => LongEncoding.toEncoding
+      case DaysSince           => IntEncoding.toEncoding
+      case CountBy             => StructEncoding(Map()).toEncoding
+      case DaysSinceEarliestBy => StructEncoding(Map()).toEncoding
+      case DaysSinceLatestBy   => StructEncoding(Map()).toEncoding
+      case Proportion(_)       => DoubleEncoding.toEncoding
     }
     expression match {
       // A short term hack for supporting feature gen based on known functions
-      case Count                        => LongEncoding
-      case LatestBy(_)                  => StructEncoding(Map())
-      case Interval(sexp)               => getExpressionEncoding(sexp, LongEncoding)
-      case Inverse(sexp)                => DoubleEncoding
-      case DaysSinceLatest              => IntEncoding
-      case DaysSinceEarliest            => IntEncoding
-      case MeanInDays                   => DoubleEncoding
-      case MeanInWeeks                  => DoubleEncoding
-      case MaximumInDays                => IntEncoding
-      case MaximumInWeeks               => IntEncoding
-      case MinimumInDays                => IntEncoding
-      case MinimumInWeeks               => IntEncoding
-      case CountDays                    => IntEncoding
-      case QuantileInDays(k, q)         => DoubleEncoding
-      case QuantileInWeeks(k, q)        => DoubleEncoding
-      case ProportionByTime(s, e)       => DoubleEncoding
-      case SumBy(_, _)                  => StructEncoding(Map())
-      case CountBySecondary(_, _)       => StructEncoding(Map())
+      case Count                        => LongEncoding.toEncoding
+      case LatestBy(_)                  => StructEncoding(Map()).toEncoding
+      case Interval(sexp)               => getExpressionEncoding(sexp, LongEncoding.toEncoding)
+      case Inverse(sexp)                => DoubleEncoding.toEncoding
+      case DaysSinceLatest              => IntEncoding.toEncoding
+      case DaysSinceEarliest            => IntEncoding.toEncoding
+      case MeanInDays                   => DoubleEncoding.toEncoding
+      case MeanInWeeks                  => DoubleEncoding.toEncoding
+      case MaximumInDays                => IntEncoding.toEncoding
+      case MaximumInWeeks               => IntEncoding.toEncoding
+      case MinimumInDays                => IntEncoding.toEncoding
+      case MinimumInWeeks               => IntEncoding.toEncoding
+      case CountDays                    => IntEncoding.toEncoding
+      case QuantileInDays(k, q)         => DoubleEncoding.toEncoding
+      case QuantileInWeeks(k, q)        => DoubleEncoding.toEncoding
+      case ProportionByTime(s, e)       => DoubleEncoding.toEncoding
+      case SumBy(_, _)                  => StructEncoding(Map()).toEncoding
+      case CountBySecondary(_, _)       => StructEncoding(Map()).toEncoding
       case BasicExpression(sexp)        => getExpressionEncoding(sexp, source)
-      case StructExpression(name, sexp) => source match {
-        case StructEncoding(values) => values.get(name).map {
-          sve => getExpressionEncoding(sexp, sve.encoding)
-        }.getOrElse(source)
-        case _                          => source
-      }
+      case StructExpression(name, sexp) => source.fold(
+        _ => source,
+        _.values.get(name).map {
+          sve => getExpressionEncoding(sexp, sve.encoding.toEncoding)
+        }.getOrElse(source),
+        _ => source
+      )
     }
   }
 }

--- a/ivory-core/src/main/scala/com/ambiata/ivory/core/Fact.scala
+++ b/ivory-core/src/main/scala/com/ambiata/ivory/core/Fact.scala
@@ -234,8 +234,7 @@ object Value {
   def validateEncoding(value: Value, encoding: Encoding): Validation[String, Unit] = {
     def fail: Validation[String, Unit] =
       s"Not a valid ${Encoding.render(encoding)}!".failure
-    (value, encoding) match {
-      case (TombstoneValue,  _)                 => Success(())
+    def validateEncodingPrim(v: PrimitiveValue, e: PrimitiveEncoding): Validation[String, Unit] = (v, e) match {
       case (BooleanValue(_), BooleanEncoding)   => Success(())
       case (BooleanValue(_), _)                 => fail
       case (IntValue(_),     IntEncoding)       => Success(())
@@ -248,19 +247,29 @@ object Value {
       case (StringValue(_),  _)                 => fail
       case (DateValue(_),    DateEncoding)      => Success(())
       case (DateValue(_),    _)                 => fail
-      case (StructValue(v),  e: StructEncoding) => validateStruct(v, e)
+    }
+    def validateEncodingSub(v: SubValue, e: SubEncoding): Validation[String, Unit] = (v, e) match {
+      case (vp: PrimitiveValue, SubPrim(ep))    => validateEncodingPrim(vp, ep)
+      case (vp: PrimitiveValue, _)              => fail
+      case (StructValue(vs),  SubStruct(es))    => validateStruct(vs, es)
       case (StructValue(_),  _)                 => fail
-      case (ListValue(v),    e: ListEncoding)   => v.foldMap(validateEncoding(_, e.encoding))
+    }
+    def validateStruct(values: Map[String, PrimitiveValue], encoding: StructEncoding): Validation[String, Unit] =
+      Maps.outerJoin(encoding.values, values).toStream.foldMap {
+        case (n, \&/.This(enc))        => if (!enc.optional) s"Missing struct $n".failure else ().success
+        case (n, \&/.That(_))          => s"Undeclared struct value $n".failure
+        case (n, \&/.Both(enc, v))     => validateEncodingPrim(v, enc.encoding).leftMap(_ + s" for $n")
+      }
+    (value, encoding) match {
+      case (TombstoneValue,  _)                 => Success(())
+      case (vp: PrimitiveValue, EncodingPrim(ep)) => validateEncodingPrim(vp, ep)
+      case (vp: PrimitiveValue, _)              => fail
+      case (StructValue(vs), EncodingStruct(es)) => validateStruct(vs, es)
+      case (StructValue(_),  _)                 => fail
+      case (ListValue(v), EncodingList(l))      => v.foldMap(validateEncodingSub(_, l.encoding))
       case (ListValue(_),    _)                 => fail
     }
   }
-
-  def validateStruct(values: Map[String, PrimitiveValue], encoding: StructEncoding): Validation[String, Unit] =
-    Maps.outerJoin(encoding.values, values).toStream.foldMap {
-      case (n, \&/.This(enc))        => if (!enc.optional) s"Missing struct $n".failure else ().success
-      case (n, \&/.That(value))      => s"Undeclared struct value $n".failure
-      case (n, \&/.Both(enc, value)) => validateEncoding(value, enc.encoding).leftMap(_ + s" for $n")
-    }
 
   def toThrift(value: Value): ThriftFactValue = {
     def primValue(p: PrimitiveValue): ThriftFactPrimitiveValue = p match {

--- a/ivory-core/src/test/scala/com/ambiata/ivory/core/EncodingSpec.scala
+++ b/ivory-core/src/test/scala/com/ambiata/ivory/core/EncodingSpec.scala
@@ -1,0 +1,18 @@
+package com.ambiata.ivory.core
+
+import com.ambiata.ivory.core.arbitraries.Arbitraries._
+import org.specs2._
+
+class EncodingSpec extends Specification with ScalaCheck { def is = s2"""
+
+Combinators
+-----------
+
+  Fold constructors is identity: $foldIdentity
+
+"""
+
+  def foldIdentity = prop { e: Encoding =>
+    e.fold(_.toEncoding, _.toEncoding, _.toEncoding) ==== e
+  }
+}

--- a/ivory-core/src/test/scala/com/ambiata/ivory/core/ExpressionSpec.scala
+++ b/ivory-core/src/test/scala/com/ambiata/ivory/core/ExpressionSpec.scala
@@ -30,15 +30,15 @@ class ExpressionSpec extends Specification with ScalaCheck { def is = s2"""
   )
 
   def validationFail = seqToResult(List(
-    BasicExpression(Sum)               -> StringEncoding,
-    BasicExpression(CountUnique)       -> IntEncoding,
-    Interval(NumFlips)                 -> LongEncoding,
-    StructExpression("a", CountUnique) -> StructEncoding(Map("b" -> mandatory(StringEncoding))),
-    StructExpression("a", Mean)        -> StructEncoding(Map("a" -> mandatory(StringEncoding))),
-    SumBy("k", "v")                    -> StringEncoding,
-    SumBy("k", "v")                    -> StructEncoding(Map("k" -> mandatory(IntEncoding), "v" -> mandatory(IntEncoding))),
-    SumBy("k", "v")                    -> StructEncoding(Map("k" -> mandatory(StringEncoding), "v" -> mandatory(BooleanEncoding))),
-    CountBySecondary("k", "v")         -> StringEncoding,
-    CountBySecondary("k", "v")         -> StructEncoding(Map("k" -> mandatory(StringEncoding)))
+    BasicExpression(Sum)               -> StringEncoding.toEncoding,
+    BasicExpression(CountUnique)       -> IntEncoding.toEncoding,
+    Interval(NumFlips)                 -> LongEncoding.toEncoding,
+    StructExpression("a", CountUnique) -> StructEncoding(Map("b" -> mandatory(StringEncoding))).toEncoding,
+    StructExpression("a", Mean)        -> StructEncoding(Map("a" -> mandatory(StringEncoding))).toEncoding,
+    SumBy("k", "v")                    -> StringEncoding.toEncoding,
+    SumBy("k", "v")                    -> StructEncoding(Map("k" -> mandatory(IntEncoding), "v" -> mandatory(IntEncoding))).toEncoding,
+    SumBy("k", "v")                    -> StructEncoding(Map("k" -> mandatory(StringEncoding), "v" -> mandatory(BooleanEncoding))).toEncoding,
+    CountBySecondary("k", "v")         -> StringEncoding.toEncoding,
+    CountBySecondary("k", "v")         -> StructEncoding(Map("k" -> mandatory(StringEncoding))).toEncoding
   ).map((Expression.validate _).tupled).map(_.toEither must beLeft))
 }

--- a/ivory-core/src/test/scala/com/ambiata/ivory/core/FilterSpec.scala
+++ b/ivory-core/src/test/scala/com/ambiata/ivory/core/FilterSpec.scala
@@ -24,19 +24,19 @@ class FilterSpec extends Specification with ScalaCheck { def is = s2"""
 
   def invalidEncodedValue = {
     val values = FilterValues(FilterValuesOp(FilterOpAnd, List(FilterEquals(IntValue(1))), Nil))
-    FilterTextV0.encode(FilterTextV0.asString(values), BooleanEncoding).toEither must beLeft
+    FilterTextV0.encode(FilterTextV0.asString(values), BooleanEncoding.toEncoding).toEither must beLeft
   }
 
   def invalidStructName = {
     val struct = FilterStruct(FilterStructOp(FilterOpAnd, List("a" -> FilterEquals(StringValue("b"))), Nil))
-    FilterTextV0.encode(FilterTextV0.asString(struct), StructEncoding(Map())).toEither must beLeft
+    FilterTextV0.encode(FilterTextV0.asString(struct), StructEncoding(Map()).toEncoding).toEither must beLeft
   }
 
   def missingStructValue =
-    FilterTextV0.encode(Filter("and,a"), StructEncoding(Map())).toEither must beLeft
+    FilterTextV0.encode(Filter("and,a"), StructEncoding(Map()).toEncoding).toEither must beLeft
 
   def invalidOperation =
-    FilterTextV0.encode(Filter("and,(*,x)"), StringEncoding).toEither must beLeft
+    FilterTextV0.encode(Filter("and,(*,x)"), StringEncoding.toEncoding).toEither must beLeft
 }
 
 object FilterTester {

--- a/ivory-core/src/test/scala/com/ambiata/ivory/core/SkewSpec.scala
+++ b/ivory-core/src/test/scala/com/ambiata/ivory/core/SkewSpec.scala
@@ -99,7 +99,7 @@ Skew Tests
   , Namespace("flavours"    ) -> 184072795.bytes
   )
 
-  def fake = ConcreteDefinition(DoubleEncoding, Mode.State, Some(ContinuousType), "desc", Nil)
+  def fake = ConcreteDefinition(DoubleEncoding.toEncoding, Mode.State, Some(ContinuousType), "desc", Nil)
   def optimalSize = 256.mb
 
   /** create a dictionary */

--- a/ivory-core/src/test/scala/com/ambiata/ivory/core/ValueSpec.scala
+++ b/ivory-core/src/test/scala/com/ambiata/ivory/core/ValueSpec.scala
@@ -36,8 +36,10 @@ class ValueSpec extends Specification with ScalaCheck { def is = s2"""
   // A small subset of  encoded values are valid for different optional/empty Structs/Lists
   private def isCompatible(e1: EncodingAndValue, e2: Encoding): Boolean =
     (e1, e2) match {
-      case (EncodingAndValue(_, StructValue(m)), StructEncoding(v)) => m.isEmpty && v.forall(_._2.optional)
-      case (EncodingAndValue(_, ListValue(l)), ListEncoding(e))     => l.forall(v => isCompatible(EncodingAndValue(e, v), e))
+      case (EncodingAndValue(_, StructValue(m)), EncodingStruct(StructEncoding(v))) =>
+        m.isEmpty && v.forall(_._2.optional)
+      case (EncodingAndValue(_, ListValue(l)), EncodingList(ListEncoding(e))) =>
+        l.forall(v => isCompatible(EncodingAndValue(e.toEncoding, v), e.toEncoding))
       case _ => false
     }
 

--- a/ivory-core/src/test/scala/com/ambiata/ivory/core/arbitraries/DefinitionWithQuery.scala
+++ b/ivory-core/src/test/scala/com/ambiata/ivory/core/arbitraries/DefinitionWithQuery.scala
@@ -3,8 +3,7 @@ package com.ambiata.ivory.core.arbitraries
 import com.ambiata.ivory.core._
 import com.ambiata.ivory.core.gen._
 
-import org.scalacheck._, Arbitrary._
-import Arbitraries._
+import org.scalacheck._
 
 
 /** namespace for features */
@@ -13,10 +12,7 @@ case class DefinitionWithQuery(cd: ConcreteDefinition, expression: Expression, f
 object DefinitionWithQuery {
   implicit def DefinitionWithQueryArbitrary: Arbitrary[DefinitionWithQuery] =
     Arbitrary(for {
-      cd <- GenDictionary.concreteWith(Gen.oneOf(
-          arbitrary[PrimitiveEncoding]
-        , arbitrary[StructEncoding]
-        ))
+      cd <- GenDictionary.concreteWith(GenDictionary.subEncoding.map(_.toEncoding))
       e <- GenDictionary.expression(cd)
       f <- GenDictionary.filter(cd)
     } yield DefinitionWithQuery(cd, e, f.get))

--- a/ivory-core/src/test/scala/com/ambiata/ivory/core/arbitraries/PrimitiveSparseEntities.scala
+++ b/ivory-core/src/test/scala/com/ambiata/ivory/core/arbitraries/PrimitiveSparseEntities.scala
@@ -17,6 +17,6 @@ case class PrimitiveSparseEntities(meta: ConcreteDefinition, fact: Fact, zone: D
 
 object PrimitiveSparseEntities {
   implicit def PrimitiveSparseEntitiesArbitrary: Arbitrary[PrimitiveSparseEntities] =
-    Arbitrary(GenFact.factWithZone(GenEntity.entity, GenDictionary.concreteWith(arbitrary[PrimitiveEncoding]))
+    Arbitrary(GenFact.factWithZone(GenEntity.entity, GenDictionary.concreteWith(arbitrary[PrimitiveEncoding].map(_.toEncoding)))
       .map((PrimitiveSparseEntities.apply _).tupled))
 }

--- a/ivory-core/src/test/scala/com/ambiata/ivory/core/gen/GenDictionary.scala
+++ b/ivory-core/src/test/scala/com/ambiata/ivory/core/gen/GenDictionary.scala
@@ -15,10 +15,10 @@ object GenDictionary {
     Gen.oneOf(NumericalType, ContinuousType, CategoricalType, BinaryType)
 
   def encoding: Gen[Encoding] =
-    Gen.oneOf(subEncoding, listEncoding)
+    Gen.oneOf(subEncoding.map(_.toEncoding), listEncoding.map(_.toEncoding))
 
   def subEncoding: Gen[SubEncoding] =
-    Gen.oneOf(primitiveEncoding, structEncoding)
+    Gen.oneOf(primitiveEncoding.map(SubPrim), structEncoding.map(SubStruct))
 
   def listEncoding: Gen[ListEncoding] =
     subEncoding.map(ListEncoding)
@@ -98,8 +98,14 @@ object GenDictionary {
         e <- Gen.oneOf(QuantileInDays(k, q), QuantileInWeeks(k, q))
       } yield e)
     )
-    Gen.oneOf(fallback, cd.encoding match {
-      case StructEncoding(values) =>
+    Gen.oneOf(fallback, cd.encoding.fold(
+      p => Gen.oneOf(subExpression(p).map(BasicExpression),
+        p match {
+          case IntEncoding | LongEncoding | DoubleEncoding => numericSubs.map(x => Inverse(BasicExpression(x)))
+          case _ => Gen.const(NumFlips).map( x=> Inverse(BasicExpression(x)))
+        }),
+      s => {
+        val values = s.values
         def subexpsWithInverses(name: String, sve: PrimitiveEncoding, cd: ConcreteDefinition) =
           subExpression(sve).flatMap(se =>
             Gen.oneOf(
@@ -120,13 +126,9 @@ object GenDictionary {
           ie <- values.find(v => v._1 != se && List(StringEncoding).contains(v._2.encoding)).map(ie => CountBySecondary(se, ie._1)) orElse
             values.find(v => List(IntEncoding, LongEncoding, DoubleEncoding).contains(v._2.encoding)).map(ie => SumBy(se, ie._1))
         } yield ie).cata(v => Gen.frequency(5 -> Gen.const(v), 5 -> subexpGen), subexpGen)
-      case p: PrimitiveEncoding   => Gen.oneOf(subExpression(p).map(BasicExpression),
-                  p match {
-                    case IntEncoding | LongEncoding | DoubleEncoding => numericSubs.map(x => Inverse(BasicExpression(x)))
-                    case _ => Gen.const(NumFlips).map( x=> Inverse(BasicExpression(x)))
-                  })
-      case l: ListEncoding        => fallback
-    })
+      },
+      _ => fallback
+    ))
   }
 
   def subExpression(pe: PrimitiveEncoding): Gen[SubExpression] = {
@@ -167,8 +169,20 @@ object GenDictionary {
         FilterEquals(x), FilterLessThan(x), FilterLessThanOrEqual(x), FilterGreaterThan(x), FilterGreaterThanOrEqual(x)
       ) else Gen.oneOf(FilterEquals(x), FilterNotEquals(x))}
 
-    cd.encoding match {
-      case se: StructEncoding =>
+    cd.encoding.fold(
+      pe => {
+        def sub(maxChildren: Int): Gen[FilterValuesOp] =
+          for {
+            op     <- Gen.oneOf(FilterOpAnd, FilterOpOr)
+            // Make sure we have at least one value
+            // For non-struct values it's impossible to equal more than one value
+            n      <- Gen.choose(1, op.fold(1, 3))
+            fields <- Gen.listOfN(n, filterExpression(pe))
+            cn     <- op.fold(Gen.const(0), Gen.choose(0, maxChildren))
+            chlds  <- Gen.listOfN(cn, sub(maxChildren - 1))
+          } yield FilterValuesOp(op, fields, chlds)
+        sub(2).map(FilterValues).map(some)
+      }, se => {
         def sub(maxChildren: Int, left: Map[String, StructEncodedValue]): Gen[FilterStructOp] =
           for {
           // Be careful in this section - ScalaCheck will discard values if asking for move than is contained
@@ -186,21 +200,10 @@ object GenDictionary {
             chlds  <- Gen.listOfN(Math.min(subvs.size, cn), sub(maxChildren - 1, subvs))
           } yield FilterStructOp(op, fields, chlds)
         sub(2, se.values).map(FilterStruct).map(some)
-      case pe: PrimitiveEncoding =>
-        def sub(maxChildren: Int): Gen[FilterValuesOp] =
-          for {
-            op     <- Gen.oneOf(FilterOpAnd, FilterOpOr)
-            // Make sure we have at least one value
-            // For non-struct values it's impossible to equal more than one value
-            n      <- Gen.choose(1, op.fold(1, 3))
-            fields <- Gen.listOfN(n, filterExpression(pe))
-            cn     <- op.fold(Gen.const(0), Gen.choose(0, maxChildren))
-            chlds  <- Gen.listOfN(cn, sub(maxChildren - 1))
-          } yield FilterValuesOp(op, fields, chlds)
-        sub(2).map(FilterValues).map(some)
+      },
       // We don't support list encoding at the moment
-      case _: ListEncoding => Gen.const(none)
-    }
+      _ => Gen.const(none)
+    )
   }
 
   /** Require an index for this definition to guarantee uniqueness of feature ids across the dictionary */

--- a/ivory-core/src/test/scala/com/ambiata/ivory/core/gen/GenDictionary.scala
+++ b/ivory-core/src/test/scala/com/ambiata/ivory/core/gen/GenDictionary.scala
@@ -183,7 +183,7 @@ object GenDictionary {
           } yield FilterValuesOp(op, fields, chlds)
         sub(2).map(FilterValues).map(some)
       }, se => {
-        def sub(maxChildren: Int, left: Map[String, StructEncodedValue]): Gen[FilterStructOp] =
+        def sub(maxChildren: Int, left: Map[String, StructEncodedValue[PrimitiveEncoding]]): Gen[FilterStructOp] =
           for {
           // Be careful in this section - ScalaCheck will discard values if asking for move than is contained
           // in a list, which can break some of the MR specs that have a low minTestsOk value (eg SquashSpec).

--- a/ivory-operation/src/main/scala/com/ambiata/ivory/operation/extraction/output/DictionaryOutput.scala
+++ b/ivory-operation/src/main/scala/com/ambiata/ivory/operation/extraction/output/DictionaryOutput.scala
@@ -21,7 +21,7 @@ object DictionaryOutput {
           val (source, mode) = dictionary.byFeatureId.get(vd.source).flatMap {
             case Concrete(_, cd) => Some(cd.encoding -> cd.mode)
             case Virtual(_, _)   => None
-          }.getOrElse(StringEncoding -> Mode.State)
+          }.getOrElse(StringEncoding.toEncoding -> Mode.State)
           ConcreteDefinition(Expression.expressionEncoding(vd.query.expression, source), mode, None, "", missing.toList)
       }), delim.toString)
     })

--- a/ivory-operation/src/main/scala/com/ambiata/ivory/operation/ingestion/DictionaryImportValidate.scala
+++ b/ivory-operation/src/main/scala/com/ambiata/ivory/operation/ingestion/DictionaryImportValidate.scala
@@ -16,15 +16,15 @@ object DictionaryImportValidate {
   def validate(oldDict: Dictionary, newDict: Dictionary): DictValidationUnit = {
     def validateEncoding(e1: Encoding, e2: Encoding, path: ValidationPath): DictValidationUnit = {
       (e1, e2) match {
-        case (StructEncoding(sm1), StructEncoding(sm2)) =>
+        case (EncodingStruct(StructEncoding(sm1)), EncodingStruct(StructEncoding(sm2))) =>
           Maps.outerJoin(sm1, sm2).toStream.foldMap {
             case (name, \&/.This(_))                   => MissingStructField(name :: path).failureNel
             case (name, \&/.That(sv2))                 => if (!sv2.optional) NotOptionalStructField(name :: path).failureNel else OK
             case (name, \&/.Both(sv1, sv2))            => () match {
               case _ if sv1 == sv2                     => OK
-              case _ if sv1.encoding != sv2.encoding   => EncodingChanged(sv1.encoding, sv2.encoding, name :: path).failureNel
+              case _ if sv1.encoding != sv2.encoding   => EncodingChanged(sv1.encoding.toEncoding, sv2.encoding.toEncoding, name :: path).failureNel
               case _ if !sv2.optional                  => NotOptionalStructField(name :: path).failureNel
-              case _                                   => validateEncoding(sv1.encoding, sv2.encoding, name :: path)
+              case _                                   => validateEncoding(sv1.encoding.toEncoding, sv2.encoding.toEncoding, name :: path)
             }
           }
         case _ if e1 != e2                             => EncodingChanged(e1, e2, path).failureNel

--- a/ivory-operation/src/test/scala/com/ambiata/ivory/operation/extraction/SnapshotsSpec.scala
+++ b/ivory-operation/src/test/scala/com/ambiata/ivory/operation/extraction/SnapshotsSpec.scala
@@ -55,7 +55,7 @@ class SnapshotsSpec extends Specification with ScalaCheck { def is = s2"""
 
   def sets = propNoShrink((concrete: FeatureId, virtual: FeatureId, window: Window, date: Date, time: Time, entity: Int) => {
     val dictionary = Dictionary(List(
-      Definition.concrete(concrete, IntEncoding, Mode.Set, None, concrete.toString, Nil)
+      Definition.concrete(concrete, IntEncoding.toEncoding, Mode.Set, None, concrete.toString, Nil)
     , Definition.virtual(virtual, concrete, Query(Count, None), Some(window))
     ))
 

--- a/ivory-operation/src/test/scala/com/ambiata/ivory/operation/ingestion/DictionaryImportValidateSpec.scala
+++ b/ivory-operation/src/test/scala/com/ambiata/ivory/operation/ingestion/DictionaryImportValidateSpec.scala
@@ -90,14 +90,15 @@ class DictionaryImportValidateSpec extends Specification with ScalaCheck { def i
 
   // At some point it might be worth investigating Prism's from Monocle to share this code with the actual logic
   private def structChecks(enc: PrimitiveEncoding, path: ValidationPath):
-      List[((Option[StructEncodedValue], Option[StructEncodedValue]), Option[DictionaryValidateFailure])] = List(
+      List[((Option[StructEncodedValue[PrimitiveEncoding]], Option[StructEncodedValue[PrimitiveEncoding]]), Option[DictionaryValidateFailure])] = List(
     None                                   -> Some(StructEncodedValue(enc).opt)     -> None,
     None                                   -> Some(StructEncodedValue(enc))         -> Some(NotOptionalStructField(path)),
     Some(StructEncodedValue(enc).opt)      -> Some(StructEncodedValue(enc))         -> Some(NotOptionalStructField(path)),
     Some(StructEncodedValue(enc))          -> Some(StructEncodedValue(enc))         -> None,
     Some(StructEncodedValue(enc))          -> Some(StructEncodedValue(enc).opt)     -> None,
     Some(StructEncodedValue(enc))          -> None                                  -> Some(MissingStructField(path)),
-    Some(StructEncodedValue(LongEncoding)) -> Some(StructEncodedValue(IntEncoding)) -> Some(EncodingChanged(LongEncoding.toEncoding, IntEncoding.toEncoding, path))
+    Some(StructEncodedValue(LongEncoding: PrimitiveEncoding)) -> Some(StructEncodedValue(IntEncoding: PrimitiveEncoding))
+      -> Some(EncodingChanged(LongEncoding.toEncoding, IntEncoding.toEncoding, path))
   )
 
   private def dict(enc: Encoding): Dictionary =

--- a/ivory-operation/src/test/scala/com/ambiata/ivory/operation/ingestion/DictionaryImportValidateSpec.scala
+++ b/ivory-operation/src/test/scala/com/ambiata/ivory/operation/ingestion/DictionaryImportValidateSpec.scala
@@ -91,13 +91,13 @@ class DictionaryImportValidateSpec extends Specification with ScalaCheck { def i
   // At some point it might be worth investigating Prism's from Monocle to share this code with the actual logic
   private def structChecks(enc: PrimitiveEncoding, path: ValidationPath):
       List[((Option[StructEncodedValue[PrimitiveEncoding]], Option[StructEncodedValue[PrimitiveEncoding]]), Option[DictionaryValidateFailure])] = List(
-    None                                   -> Some(StructEncodedValue(enc).opt)     -> None,
-    None                                   -> Some(StructEncodedValue(enc))         -> Some(NotOptionalStructField(path)),
-    Some(StructEncodedValue(enc).opt)      -> Some(StructEncodedValue(enc))         -> Some(NotOptionalStructField(path)),
-    Some(StructEncodedValue(enc))          -> Some(StructEncodedValue(enc))         -> None,
-    Some(StructEncodedValue(enc))          -> Some(StructEncodedValue(enc).opt)     -> None,
-    Some(StructEncodedValue(enc))          -> None                                  -> Some(MissingStructField(path)),
-    Some(StructEncodedValue(LongEncoding: PrimitiveEncoding)) -> Some(StructEncodedValue(IntEncoding: PrimitiveEncoding))
+    None                                        -> Some(StructEncodedValue.mandatory(enc).opt) -> None,
+    None                                        -> Some(StructEncodedValue.mandatory(enc))     -> Some(NotOptionalStructField(path)),
+    Some(StructEncodedValue.mandatory(enc).opt) -> Some(StructEncodedValue.mandatory(enc))     -> Some(NotOptionalStructField(path)),
+    Some(StructEncodedValue.mandatory(enc))     -> Some(StructEncodedValue.mandatory(enc))     -> None,
+    Some(StructEncodedValue.mandatory(enc))     -> Some(StructEncodedValue.mandatory(enc).opt) -> None,
+    Some(StructEncodedValue.mandatory(enc))     -> None                                        -> Some(MissingStructField(path)),
+    Some(StructEncodedValue.mandatory(LongEncoding)) -> Some(StructEncodedValue.mandatory(IntEncoding))
       -> Some(EncodingChanged(LongEncoding.toEncoding, IntEncoding.toEncoding, path))
   )
 

--- a/ivory-operation/src/test/scala/com/ambiata/ivory/operation/ingestion/DictionaryImporterSpec.scala
+++ b/ivory-operation/src/test/scala/com/ambiata/ivory/operation/ingestion/DictionaryImporterSpec.scala
@@ -39,7 +39,7 @@ class DictionaryImporterSpec extends Specification with ThrownExpectations with 
   def local = prop((local: LocalTemporary) => for {
     dir  <- local.directoryThatExists
     conf <- IvoryConfigurationTemporary.random.conf
-    dict = Dictionary(List(Definition.concrete(FeatureId(Namespace("demo"), "postcode"), StringEncoding, Mode.State, Some(CategoricalType), "Postcode", List("☠"))))
+    dict = Dictionary(List(Definition.concrete(FeatureId(Namespace("demo"), "postcode"), StringEncoding.toEncoding, Mode.State, Some(CategoricalType), "Postcode", List("☠"))))
     repo = Repository.fromIvoryLocation(LocalIvoryLocation.create(dir), conf)
     path = dir <|> "dictionary.psv"
     _    <- Streams.write(new java.io.FileOutputStream(path.toFile), DictionaryTextStorageV2.delimitedString(dict))
@@ -50,8 +50,8 @@ class DictionaryImporterSpec extends Specification with ThrownExpectations with 
   def updated = prop((local: LocalTemporary) => for {
     dir   <- local.directory
     conf  <- IvoryConfigurationTemporary.random.conf
-    dict1 = Dictionary(List(Definition.concrete(FeatureId(Namespace("a"), "b"), StringEncoding, Mode.State, Some(CategoricalType), "", Nil)))
-    dict2 = Dictionary(List(Definition.concrete(FeatureId(Namespace("c"), "d"), StringEncoding, Mode.State, Some(CategoricalType), "", Nil)))
+    dict1 = Dictionary(List(Definition.concrete(FeatureId(Namespace("a"), "b"), StringEncoding.toEncoding, Mode.State, Some(CategoricalType), "", Nil)))
+    dict2 = Dictionary(List(Definition.concrete(FeatureId(Namespace("c"), "d"), StringEncoding.toEncoding, Mode.State, Some(CategoricalType), "", Nil)))
     repo  = Repository.fromIvoryLocation(LocalIvoryLocation.create(dir), conf)
     _     <- fromDictionary(repo, dict1, opts.copy(ty = Override))
     _     <- fromDictionary(repo, dict2, opts.copy(ty = Update))
@@ -61,8 +61,8 @@ class DictionaryImporterSpec extends Specification with ThrownExpectations with 
 
   def invalidUpgrade(force: Boolean) = {
     val fid = FeatureId(Namespace("a"), "b")
-    val dict1 = Dictionary(List(Definition.concrete(fid, StringEncoding, Mode.State, Some(CategoricalType), "", Nil)))
-    val dict2 = Dictionary(List(Definition.concrete(fid, BooleanEncoding, Mode.State, Some(CategoricalType), "", Nil)))
+    val dict1 = Dictionary(List(Definition.concrete(fid, StringEncoding.toEncoding, Mode.State, Some(CategoricalType), "", Nil)))
+    val dict2 = Dictionary(List(Definition.concrete(fid, BooleanEncoding.toEncoding, Mode.State, Some(CategoricalType), "", Nil)))
     LocalTemporary.random.directory >>= { dir =>
       val repo = LocalRepository.create(dir)
       fromDictionary(repo, dict1, opts.copy(ty = Override))
@@ -89,8 +89,8 @@ class DictionaryImporterSpec extends Specification with ThrownExpectations with 
 
 
   def dictionaryDirectory = {
-    val dict1 = Dictionary(List(Definition.concrete(FeatureId(Namespace("a"), "b"), StringEncoding, Mode.State, Some(CategoricalType), "", Nil)))
-    val dict2 = Dictionary(List(Definition.concrete(FeatureId(Namespace("c"), "d"), StringEncoding, Mode.State, Some(CategoricalType), "", Nil)))
+    val dict1 = Dictionary(List(Definition.concrete(FeatureId(Namespace("a"), "b"), StringEncoding.toEncoding, Mode.State, Some(CategoricalType), "", Nil)))
+    val dict2 = Dictionary(List(Definition.concrete(FeatureId(Namespace("c"), "d"), StringEncoding.toEncoding, Mode.State, Some(CategoricalType), "", Nil)))
 
     withRepository(Posix) { ivory => for {
       _   <- Repositories.create(ivory, RepositoryConfig.testing)

--- a/ivory-operation/src/test/scala/com/ambiata/ivory/operation/rename/RenameSpec.scala
+++ b/ivory-operation/src/test/scala/com/ambiata/ivory/operation/rename/RenameSpec.scala
@@ -69,8 +69,8 @@ Rename
       StringFact("eid1", fid, Date.fromLocalDate(new LocalDate(2012, 9, d)), Time.unsafe(t), v)
     val mapping = RenameMapping(List(id -> tid))
     val dictionary = Dictionary(List(
-      Definition.concrete(id, StringEncoding, Mode.State, None, "", Nil),
-      Definition.concrete(tid, StringEncoding, Mode.State, None, "", Nil)
+      Definition.concrete(id, StringEncoding.toEncoding, Mode.State, None, "", Nil),
+      Definition.concrete(tid, StringEncoding.toEncoding, Mode.State, None, "", Nil)
     ))
     // This tests that identical entities handle priorities correct
     renameWithFacts(mapping, dictionary, List(

--- a/ivory-storage/src/main/scala/com/ambiata/ivory/storage/metadata/DictionaryTextStorage.scala
+++ b/ivory-storage/src/main/scala/com/ambiata/ivory/storage/metadata/DictionaryTextStorage.scala
@@ -56,7 +56,7 @@ object DictionaryTextStorage extends TextStorage[(FeatureId, ConcreteDefinition)
       } yield r
       desc      <- string
       tombstone <- string
-    } yield (FeatureId(namespace, name), ConcreteDefinition(encoding, Mode.State, Some(ty), desc, Delimited.parseCsv(tombstone)))
+    } yield (FeatureId(namespace, name), ConcreteDefinition(encoding.toEncoding, Mode.State, Some(ty), desc, Delimited.parseCsv(tombstone)))
     parser.run(Delimited.parsePsv(entry))
   }
 

--- a/ivory-storage/src/main/scala/com/ambiata/ivory/storage/parse/EavtParsers.scala
+++ b/ivory-storage/src/main/scala/com/ambiata/ivory/storage/parse/EavtParsers.scala
@@ -45,10 +45,11 @@ object EavtParsers {
       case Virtual(_, _)   => s"Cannot import virtual feature $fid".failure
     }.getOrElse(s"Could not find dictionary entry for '${fid}'".failure)
 
-  def valueFromString(meta: ConcreteDefinition, raw: String): Validation[String, Value] = meta.encoding match {
-    case _ if meta.tombstoneValue.contains(raw)  => TombstoneValue.success[String]
-    case p: PrimitiveEncoding                    => Value.parsePrimitive(p, raw)
-    case s: StructEncoding                       => "Struct encoding not supported".failure
-    case _: ListEncoding                         => "List encoding not supported".failure
-  }
+  def valueFromString(meta: ConcreteDefinition, raw: String): Validation[String, Value] =
+    if (meta.tombstoneValue.contains(raw)) TombstoneValue.success[String]
+    else  meta.encoding.fold(
+      p => Value.parsePrimitive(p, raw),
+      _ => "Struct encoding not supported".failure,
+      _ => "List encoding not supported".failure
+  )
 }


### PR DESCRIPTION
Complain and ye shall receive.

The names of the new types are kinda sucky. Happy to rename if people have suggestions.

Not sure about the last two commits and the change to `StructEncodedValue` - but that made it possible to add `foldRec`.

Depending on how this is received I'm happy to do `Value` next.