### PR TITLE
Use readUtf8 for SyncExtractSpec.file

### DIFF
--- a/ivory-storage/src/test/scala/com/ambiata/ivory/storage/sync/SyncExtractSpec.scala
+++ b/ivory-storage/src/test/scala/com/ambiata/ivory/storage/sync/SyncExtractSpec.scala
@@ -43,8 +43,8 @@ Sync operations from cluster
             o = OutputDataset(output.location)
             _ <- SyncExtract.outputDataset(dataset, cluster, o)
             e <- IvoryLocation.exists(output)
-            d <- IvoryLocation.readLines(output)
-        } yield e -> d.mkString
+            d <- IvoryLocation.readUtf8(output)
+        } yield e -> d
         })
       )
     ) must beOkValue(true -> data)
@@ -63,9 +63,9 @@ Sync operations from cluster
             _ <- SyncExtract.outputDataset(dataset, cluster, o)
             f <- IvoryLocation.exists(output </> FilePath.unsafe("foo"))
             b <- IvoryLocation.exists(output </> DirPath.unsafe("foos") </> FilePath.unsafe("bar"))
-            d <- IvoryLocation.readLines(output </> FilePath.unsafe("foo"))
-            e <- IvoryLocation.readLines(output </> DirPath.unsafe("foos") </> FilePath.unsafe("bar"))
-        } yield (f, b, d.mkString, e.mkString)
+            d <- IvoryLocation.readUtf8(output </> FilePath.unsafe("foo"))
+            e <- IvoryLocation.readUtf8(output </> DirPath.unsafe("foos") </> FilePath.unsafe("bar"))
+        } yield (f, b, d, e)
         })
       })
     ) must beOkValue((true, true, data, data))

--- a/ivory-storage/src/test/scala/com/ambiata/ivory/storage/sync/SyncExtractSpec.scala
+++ b/ivory-storage/src/test/scala/com/ambiata/ivory/storage/sync/SyncExtractSpec.scala
@@ -36,7 +36,7 @@ Sync operations from cluster
   def file = prop((data: String, location: TemporaryType) => {
     withCluster(cluster =>
       withIvoryLocationFile(TemporaryType.Hdfs)(hdfs =>
-        withIvoryLocationFile(TemporaryType.Hdfs)(output => {
+        withIvoryLocationFile(location)(output => {
           val dataset = help(hdfs.location)
           for {
             _ <- IvoryLocation.writeUtf8(hdfs, data)


### PR DESCRIPTION
/cc @nhibberd 

https://ci.ambiata.com/job/ivory.cdh4/365/

```
04:22:06 [error]  A counter-example is [, Posix] (after 5 tries)
04:22:06 [error]  '(true,)' is not equal to '(true,)' (RIOMatcher.scala:48)
```