### PR TITLE
Remove MrFactConverter from Mapper companions

### DIFF
--- a/ivory-operation/src/main/scala/com/ambiata/ivory/operation/extraction/ChordJob.scala
+++ b/ivory-operation/src/main/scala/com/ambiata/ivory/operation/extraction/ChordJob.scala
@@ -194,7 +194,8 @@ abstract class ChordFactsetMapper[K <: Writable] extends CombinableMapper[K, Byt
    * 2. chord.<version>.skip - number of facts skipped because they were in the future
    */
   override def map(key: K, value: BytesWritable, context: MapperContext[K]): Unit = {
-    ChordFactsetMapper.map(fact, converter, key, value, priority, kout, vout, emitter, okCounter, skipCounter, dropCounter, serializer,
+    converter.convert(fact, key, value)
+    ChordFactsetMapper.map(fact, priority, kout, vout, emitter, okCounter, skipCounter, dropCounter, serializer,
       featureIdLookup, entities)
   }
 }
@@ -204,10 +205,10 @@ class ChordV2FactsetMapper extends ChordFactsetMapper[NullWritable] with MrFacts
 
 object ChordFactsetMapper {
 
-  def map[K <: Writable](fact: MutableFact, converter: MrFactConverter[K, BytesWritable], key: K, value: BytesWritable, priority: Priority,
-          kout: BytesWritable, vout: BytesWritable, emitter: Emitter[BytesWritable, BytesWritable], okCounter: Counter,
-          skipCounter: Counter, dropCounter: Counter, deserializer: ThriftSerialiser, featureIdLookup: FeatureIdLookup, entities: Entities) {
-    converter.convert(fact, key, value)
+  def map(fact: MutableFact, priority: Priority, kout: BytesWritable, vout: BytesWritable,
+          emitter: Emitter[BytesWritable, BytesWritable], okCounter: Counter, skipCounter: Counter,
+          dropCounter: Counter, deserializer: ThriftSerialiser, featureIdLookup: FeatureIdLookup,
+          entities: Entities) {
     val name = fact.featureId.toString
     val featureId = featureIdLookup.getIds.get(name)
     if (featureId == null)

--- a/ivory-operation/src/main/scala/com/ambiata/ivory/operation/extraction/SnapshotJob.scala
+++ b/ivory-operation/src/main/scala/com/ambiata/ivory/operation/extraction/SnapshotJob.scala
@@ -200,8 +200,9 @@ abstract class SnapshotFactsetMapper[K <: Writable] extends CombinableMapper[K, 
    * 2. snapshot.<version>.skip - number of facts skipped because they were in the future
    */
   override def map(key: K, value: BytesWritable, context: MapperContext[K]): Unit = {
-    SnapshotFactsetMapper.map(fact, date, converter, key, value, priority, kout, vout, emitter,
-                              okCounter, skipCounter, dropCounter, serializer, featureIdLookup)
+    converter.convert(fact, key, value)
+    SnapshotFactsetMapper.map(fact, date, priority, kout, vout, emitter, okCounter, skipCounter, dropCounter,
+      serializer, featureIdLookup)
   }
 }
 
@@ -210,11 +211,9 @@ class SnapshotV2FactsetMapper extends SnapshotFactsetMapper[NullWritable] with M
 
 object SnapshotFactsetMapper {
 
-  def map[K <: Writable](fact: MutableFact, date: Date, converter: MrFactConverter[K, BytesWritable], key: K, value: BytesWritable,
-                         priority: Priority, kout: BytesWritable, vout: BytesWritable, emitter: Emitter[BytesWritable, BytesWritable],
-                         okCounter: Counter, skipCounter: Counter, dropCounter: Counter, deserializer: ThriftSerialiser,
-                         featureIdLookup: FeatureIdLookup) {
-    converter.convert(fact, key, value)
+  def map(fact: MutableFact, date: Date, priority: Priority, kout: BytesWritable, vout: BytesWritable,
+          emitter: Emitter[BytesWritable, BytesWritable], okCounter: Counter, skipCounter: Counter,
+          dropCounter: Counter, deserializer: ThriftSerialiser, featureIdLookup: FeatureIdLookup) {
     val name = fact.featureId.toString
     val featureId = featureIdLookup.getIds.get(name)
     if (featureId == null)
@@ -274,7 +273,8 @@ abstract class SnapshotIncrementalMapper[K <: Writable] extends CombinableMapper
   }
 
   override def map(key: K, value: BytesWritable, context: MapperContext[K]): Unit = {
-    SnapshotIncrementalMapper.map(fact, key, value, Priority.Max, kout, vout, emitter, okCounter, dropCounter, serializer, featureIdLookup, converter)
+    converter.convert(fact, key, value)
+    SnapshotIncrementalMapper.map(fact, Priority.Max, kout, vout, emitter, okCounter, dropCounter, serializer, featureIdLookup)
   }
 }
 
@@ -282,11 +282,9 @@ class SnapshotV1IncrementalMapper extends SnapshotIncrementalMapper[NullWritable
 class SnapshotV2IncrementalMapper extends SnapshotIncrementalMapper[IntWritable] with MrSnapshotFactFormatV2
 
 object SnapshotIncrementalMapper {
-  def map[K <: Writable](fact: MutableFact, key: K, value: BytesWritable, priority: Priority, kout: BytesWritable,
-                         vout: BytesWritable, emitter: Emitter[BytesWritable, BytesWritable], okCounter: Counter,
-                         dropCounter: Counter, serializer: ThriftSerialiser, featureIdLookup: FeatureIdLookup,
-                         converter: MrFactConverter[K, BytesWritable]) {
-    converter.convert(fact, key, value)
+  def map(fact: MutableFact, priority: Priority, kout: BytesWritable, vout: BytesWritable,
+          emitter: Emitter[BytesWritable, BytesWritable], okCounter: Counter, dropCounter: Counter,
+          serializer: ThriftSerialiser, featureIdLookup: FeatureIdLookup) {
     val name = fact.featureId.toString
     val featureId = featureIdLookup.getIds.get(name)
     if (featureId == null)

--- a/ivory-operation/src/test/scala/com/ambiata/ivory/operation/extraction/ChordFactsetMapperSpec.scala
+++ b/ivory-operation/src/test/scala/com/ambiata/ivory/operation/extraction/ChordFactsetMapperSpec.scala
@@ -2,9 +2,7 @@ package com.ambiata.ivory.operation.extraction
 
 import com.ambiata.ivory.core._
 import com.ambiata.ivory.core.arbitraries.Arbitraries._
-import com.ambiata.ivory.storage.fact._
 import com.ambiata.poacher.mr._
-import org.apache.hadoop.io._
 import org.specs2._
 
 class ChordFactsetMapperSpec extends Specification with ScalaCheck { def is = s2"""
@@ -27,10 +25,7 @@ class ChordFactsetMapperSpec extends Specification with ScalaCheck { def is = s2
 
   def map(f: Fact, context: ChordMapperSpecContext, priority: Priority): Unit = {
     ChordFactsetMapper.map(
-      createMutableFact
-      , PartitionFactConverter(f.partition)
-      , NullWritable.get
-      , new BytesWritable(context.serializer.toBytes(f.toThrift))
+        f.toNamespacedThrift
       , priority
       , Writables.bytesWritable(4096)
       , Writables.bytesWritable(4096)

--- a/ivory-operation/src/test/scala/com/ambiata/ivory/operation/extraction/SnapshotMapperSpec.scala
+++ b/ivory-operation/src/test/scala/com/ambiata/ivory/operation/extraction/SnapshotMapperSpec.scala
@@ -13,8 +13,6 @@ import org.apache.hadoop.io.{BytesWritable, IntWritable, NullWritable}
 import org.specs2._
 import org.specs2.matcher.ThrownExpectations
 
-import scalaz.NonEmptyList
-
 object SnapshotMapperSpec extends Specification with ScalaCheck with ThrownExpectations { def is = s2"""
 
 SnapshotMapperSpec


### PR DESCRIPTION
Micro PRs FTW? I think this one is a no-brainer.

I'm just adding properties for `MrFactConverter` now on another branch. /cc @raronson