### PR TITLE
Add tracing for squash reducer lookups

### DIFF
--- a/ivory-operation/src/test/scala/com/ambiata/ivory/operation/extraction/squash/SquashReducerLookupSpec.scala
+++ b/ivory-operation/src/test/scala/com/ambiata/ivory/operation/extraction/squash/SquashReducerLookupSpec.scala
@@ -28,7 +28,7 @@ class SquashReducerLookupSpec extends Specification with ScalaCheck { def is = s
   def lookup = prop((d: VirtualDictionaryWindow, d2: DictionaryWithoutKeyedSet, s: NaturalInt, e: Int) => s.value != Short.MaxValue ==> {
     val reducers = s.value.toShort
     val dict = d.vd.dictionary.append(d2.value)
-    val create = SquashReducerLookup.createLookup(dict, SquashReducerLookup.lookupByWindowOnly(dict, reducers))
+    val create = SquashReducerLookup.toLookup(dict, SquashReducerLookup.calculateOffsets(SquashReducerLookup.lookupByWindowOnly(dict, reducers)))
     val lookupV = create.reducers.get(dict.byFeatureIndexReverse.getOrElse(d.vdict.vd.source, 0))
     val windowReducers = create.reducers.values().asScala.map(_ & 0xffff).sum
     windowReducers must beGreaterThan(reducers - d2.value.byConcrete.sources.size) and


### PR DESCRIPTION
This what you had in mind @markhibberd?

Looks like:

```
=== Squash Reducers ===
Feature|Offset|Reducers
orange2:desgtzpdduLMraixyoP|0|1
white3:wX|1|2
yellow0:f_grwz|2|2
black6:wdVhcjgdbokodtrdjkE_ibdqfMuFkzeT|3|1
=======================
```