### PR TITLE
Return an empty array if there are no features to lookup 

### DIFF
--- a/ivory-storage/src/main/scala/com/ambiata/ivory/storage/lookup/FeatureLookups.scala
+++ b/ivory-storage/src/main/scala/com/ambiata/ivory/storage/lookup/FeatureLookups.scala
@@ -3,6 +3,7 @@ package com.ambiata.ivory.storage.lookup
 import com.ambiata.ivory.core._
 import com.ambiata.ivory.lookup._
 import scala.collection.JavaConverters._
+import scalaz._, Scalaz._
 
 object FeatureLookups {
 
@@ -53,7 +54,7 @@ object FeatureLookups {
     new EntityFilterLookup(features.map(_.toString).asJava, entities.asJava)
 
   def sparseMapToArray[A : scala.reflect.ClassTag](map: List[(Int, A)], default: A): Array[A] = {
-    val max = map.map(_._1).max
+    val max = map.map(_._1).maximum.getOrElse(-1)
     val array = Array.fill(max + 1)(default)
     map.foreach {
       case (i, a) => array(i) = a

--- a/ivory-storage/src/test/scala/com/ambiata/ivory/storage/lookup/FeatureLookupsSpec.scala
+++ b/ivory-storage/src/test/scala/com/ambiata/ivory/storage/lookup/FeatureLookupsSpec.scala
@@ -3,6 +3,7 @@ package com.ambiata.ivory.storage.lookup
 import com.ambiata.ivory.storage.arbitraries.DictionaryWithoutKeyedSet
 import org.specs2.{ScalaCheck, Specification}
 import scala.collection.JavaConverters._
+import scalaz._, Scalaz._
 
 class FeatureLookupsSpec extends Specification with ScalaCheck { def is = s2"""
 
@@ -63,11 +64,11 @@ spareMapToArray
     table.getFlags.asScala.count(_._2) ==== array.filter(identity).length })
 
   // Using Byte just to speed up the test - otherwise we create some _really_ big arrays
-  def sparseMapToArray = prop((ls: List[(Byte, String)]) => ls.nonEmpty ==> {
+  def sparseMapToArray = prop((ls: List[(Byte, String)]) => {
     val l = ls.toMap.map { case (i, s) => Math.abs(i) -> s }
     // Using null here as a sentinel value that we know ScalaCheck won't generate for us
     val a = FeatureLookups.sparseMapToArray(l.toList, null)
-    (a.length, a.toList.filterNot(_ == null)) ==== ((l.maxBy(_._1)._1 + 1, l.toList.sortBy(_._1).map(_._2)))
+    (a.length, a.toList.filterNot(_ == null)) ==== ((l.toList.maximumBy(_._1).map(_._1).getOrElse(-1) + 1, l.toList.sortBy(_._1).map(_._2)))
   })
 
 }


### PR DESCRIPTION
in `FeatureLookups.sparseMapToArray`.